### PR TITLE
Update outdated url

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note on ARM documents:
 - Ian Beer - [task_t considered harmful](https://googleprojectzero.blogspot.ch/2016/10/taskt-considered-harmful.html)
 - jndok - [Exploiting Pegasus on OS X](https://jndok.github.io/2016/10/04/pegasus-writeup/)
 - Siguza - [Exploiting Pegasus on iOS](https://siguza.github.io/cl0ver/)
-- Ian Beer - mach_portal ([write-up](https://bugs.chromium.org/p/project-zero/issues/detail?id=965#c2) and [presentation slides](https://bugs.chromium.org/p/project-zero/issues/attachment?aid=280146))
+- Ian Beer - mach_portal ([write-up](https://bugs.chromium.org/p/project-zero/issues/detail?id=965#c2) and [presentation slides](https://bugs.chromium.org/p/project-zero/issues/attachment?aid=280146&signed_aid=lcE7kSko3drFdbx2ApJb7A==))
 - Ian Beer - [Exception-oriented exploitation on iOS](https://googleprojectzero.blogspot.ch/2017/04/exception-oriented-exploitation-on-ios.html)
 - Jonathan Levin - [Phœnix](http://newosxbook.com/files/PhJB.pdf)
 - Gal Beniamini - Over The Air (Parts [One](https://googleprojectzero.blogspot.ch/2017/09/over-air-vol-2-pt-1-exploiting-wi-fi.html), [Two](https://googleprojectzero.blogspot.ch/2017/10/over-air-vol-2-pt-2-exploiting-wi-fi.html) and [Three](https://googleprojectzero.blogspot.ch/2017/10/over-air-vol-2-pt-3-exploiting-wi-fi.html))


### PR DESCRIPTION
Currently https://bugs.chromium.org/p/project-zero/issues/attachment?aid=280146 returns 400 status code as seems like Google implemented some kind of signature for attachments.